### PR TITLE
fix: use goog.string/format when cljs

### DIFF
--- a/src/open_spaced_repetition/cljc_fsrs/parameters.cljc
+++ b/src/open_spaced_repetition/cljc_fsrs/parameters.cljc
@@ -1,5 +1,7 @@
 (ns open-spaced-repetition.cljc-fsrs.parameters
-  #:nextjournal.clerk{:visibility {:code :show, :result :show}, :toc true})
+  #:nextjournal.clerk{:visibility {:code :show, :result :show}, :toc true}
+  #?(:cljs (:require [goog.string :refer [format]]
+                     [goog.string.format])))
 
 ;;; # Card Ratings and States
 ;; There are four possible ratings that we assign to a card on every


### PR DESCRIPTION
`format` does not exist in `cljs.core`.
We need to use goog's format instead in cljs